### PR TITLE
Changed file extension for including LaTeX diagrams to align with PlantUML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+## [1.0.0] - 2022-04-15
+
+### Changed
+
+- Updated file extension for including diagrams to `.tex` to align with changes
+  introduced in PlantUML v1.2023.0. This change is not backwards compatible with
+  older versions of PlantUML.
+
 ## [0.3.1] – 2020-05-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [1.0.0] - 2022-04-15
-
 ### Changed
 
 - Updated file extension for including diagrams to `.tex` to align with changes

--- a/plantuml.sty
+++ b/plantuml.sty
@@ -89,7 +89,7 @@
     \fi
     \ifthenelse{\equal{\PlantUmlMode}{latex}}{
       \begin{adjustbox}{max width=\linewidth}
-        \input{\PlantUMLJobname-plantuml.latex}
+        \input{\PlantUMLJobname-plantuml.tex}
       \end{adjustbox}
     }{
       \includegraphics[width=\maxwidth{\textwidth}]{\PlantUMLJobname-plantuml.\PlantUmlMode}


### PR DESCRIPTION
Closes https://github.com/koppor/plantuml/issues/28

Plantuml changed the file extension for diagrams exported to $\LaTeX$ from `.latex` to `.tex` in [this PR](https://github.com/plantuml/plantuml/pull/1237). This change breaks this package since it includes the generated `.latex` file. 

With this PR the package now includes the new `.tex` file. 


_p.s. I was the one submitting the change in plantuml. Sry for the breakage everyone :)_