### PR TITLE
Bug Fixes and update of README.md and examples

### DIFF
--- a/ExampleMultiSVGs/example-component-diagram.tex
+++ b/ExampleMultiSVGs/example-component-diagram.tex
@@ -13,20 +13,33 @@
 \usepackage[output=svg]{plantuml}
 
 \begin{document}
-\begin{plantuml}
-@startuml
-() "Interface 2" as I2
-() "Interface 3" as I3
 
-[component 1] as c1
-[component 2] as c2
-[component 3] as c3
+	\begin{plantuml}
+		@startuml
+		() "Interface 2" as I2
+		() "Interface 3" as I3
 
-c1 -- I2
-c1 -- I3
+		[component 1] as c1
+		[component 2] as c2
+		[component 3] as c3
+		
+		c1 -- I2
+		c1 -- I3
+		
+		I2 )-- c2
+		I3 )-- c3
+		@enduml
+	\end{plantuml}
+	
+\newpage
 
-I2 )-- c2
-I3 )-- c3
-@enduml
-\end{plantuml}
+	\begin{plantuml}
+		@startuml
+		class Car
+		
+		Driver - Car : drives >
+		Car *- Wheel : have 4 >
+		Car -- Person : < owns
+		@enduml
+	\end{plantuml}
 \end{document}

--- a/README.md
+++ b/README.md
@@ -69,6 +69,28 @@ Car -- Person : < owns
 \end{document}
 ```
 
+**For newer Inkscape use this LaTeX source:**
+```latex
+\documentclass{scrartcl}
+\usepackage{graphics}
+\usepackage{epstopdf}
+\epstopdfDeclareGraphicsRule{.svg}{pdf}{.pdf}{%
+  inkscape #1 --export-filename=\OutputFile
+}
+\usepackage[output=svg]{plantuml}
+\begin{document}
+\begin{plantuml}
+@startuml
+class Car
+
+Driver - Car : drives >
+Car *- Wheel : have 4 >
+Car -- Person : < owns
+@enduml
+\end{plantuml}
+\end{document}
+```
+
 **Compilation:** `lualatex -shell-escape example-class-relations`
 
 **Result:**

--- a/example-class-relations--svg.tex
+++ b/example-class-relations--svg.tex
@@ -8,7 +8,7 @@
 % We just include the SVG as is.
 \usepackage{epstopdf}
 \epstopdfDeclareGraphicsRule{.svg}{pdf}{.pdf}{%
-  inkscape -z --file=#1 --export-pdf=\OutputFile
+  inkscape #1 --export-filename=\OutputFile
 }
 
 \usepackage[output=svg]{plantuml}

--- a/plantuml.sty
+++ b/plantuml.sty
@@ -3,7 +3,7 @@
 %% SPDX-License-Identifier: LPPL-1.3c+
 \NeedsTeXFormat{LaTeX2e}\relax
 \ProvidesPackage{plantuml}
-  [2023/05/12 v0.3.2
+  [2024/02/23 v0.3.3
   Embed PlantUML diagrams in latex documents.]
 
 % Required by PlantUML LaTeX output
@@ -24,9 +24,11 @@
 
 \RequirePackage{adjustbox}
 
+\newcounter{PlantUmlFigureNumberSVG}
+\def\UMLcountUp{\stepcounter{PlantUmlFigureNumberSVG} \def\PlantUMLJobname{PlantUML\thePlantUmlFigureNumberSVG}}
 % \jobname has an encoding issue if the .tex filename includes a multibyte string.
 % One needs to redefine PlantUMLJobname to fix it
-\def\PlantUMLJobname{\jobname}
+\def\PlantUMLJobname{\jobname\thePlantUmlFigureNumberSVG}
 
 \ExplSyntaxOn
 \keys_define:nn { plantuml } {
@@ -93,6 +95,7 @@
       \end{adjustbox}
     }{
       \includegraphics[width=\maxwidth{\textwidth}]{\PlantUMLJobname-plantuml.\PlantUmlMode}
+	  \UMLcountUp
     }
   }
 \or
@@ -102,4 +105,3 @@
   }{}
 \fi
 \makeatother
-


### PR DESCRIPTION
- Updated some examples according to: \n https://wiki.inkscape.org/wiki/index.php/Using_the_Command_Line 
- Added in the README.md 'For newer Inkscape use this LaTeX source:' 
- Added folder 'ExampleMultiSVGs' and file example-component-diagram.tex 
- Fixed bug https://github.com/koppor/plantuml/issues/17 and https://github.com/koppor/plantuml/issues/15
=>  new 'Bug' multi svg files will produce a mess of files in the folder => manually cleaning is necessary!