### PR TITLE
Fix bug when the file / directory name contains white spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Check [issue #1](https://github.com/koppor/plantuml/issues/1) for the current st
 \usepackage{graphics}
 \usepackage{epstopdf}
 \epstopdfDeclareGraphicsRule{.svg}{pdf}{.pdf}{
-  inkscape #1 --export-filename=\OutputFile
+  inkscape "#1" --export-filename="\OutputFile"
 }
 \usepackage[output=svg]{plantuml}
 \begin{document}

--- a/example-class-relations--svg.tex
+++ b/example-class-relations--svg.tex
@@ -8,7 +8,7 @@
 % We just include the SVG as is.
 \usepackage{epstopdf}
 \epstopdfDeclareGraphicsRule{.svg}{pdf}{.pdf}{%
-  inkscape #1 --export-filename=\OutputFile
+  inkscape "#1" --export-filename="\OutputFile"
 }
 
 \usepackage[output=svg]{plantuml}

--- a/example-component-diagram.tex
+++ b/example-component-diagram.tex
@@ -7,7 +7,7 @@
 % We just include the SVG as is.
 \usepackage{epstopdf}
 \epstopdfDeclareGraphicsRule{.svg}{pdf}{.pdf}{%
-  inkscape #1 --export-filename=\OutputFile
+  inkscape "#1" --export-filename="\OutputFile"
 }
 
 \usepackage[output=svg]{plantuml}

--- a/example-multiple-diagrams-svg.tex
+++ b/example-multiple-diagrams-svg.tex
@@ -4,7 +4,7 @@
 
 \usepackage{epstopdf}
 \epstopdfDeclareGraphicsRule{.svg}{pdf}{.pdf}{%
-  inkscape #1 --export-filename=\OutputFile
+  inkscape "#1" --export-filename="\OutputFile"
 }
 
 \usepackage[output=svg]{plantuml}

--- a/plantuml.lua
+++ b/plantuml.lua
@@ -31,7 +31,7 @@ function convertPlantUmlToTikz(jobname, mode)
   -- delete generated file to ensure they are really recreated
   os.remove(plantUmlTargetFilename)
 
-  cmd = cmd .. " " .. plantUmlSourceFilename
+  cmd = cmd .. [[ "]] .. plantUmlSourceFilename .. [["]]
   texio.write_nl(cmd)
   local handle,error = io.popen(cmd)
   if not handle then

--- a/plantuml.sty
+++ b/plantuml.sty
@@ -26,9 +26,18 @@
 
 \newcounter{PlantUmlFigureNumberSVG}
 \def\UMLcountUp{\stepcounter{PlantUmlFigureNumberSVG} \def\PlantUMLJobname{PlantUML\thePlantUmlFigureNumberSVG}}
-% \jobname has an encoding issue if the .tex filename includes a multibyte string.
-% One needs to redefine PlantUMLJobname to fix it
-\def\PlantUMLJobname{\jobname\thePlantUmlFigureNumberSVG}
+
+% Code snippet from Joseph Wright (https://ctan.org/home/josephwright)
+% Source: https://tex.stackexchange.com/questions/418670/avoid-quotation-marks-when-using-jobname-or-currfilename
+% according to https://tex.stackexchange.com/users/73/joseph-wright, his code on the site is placed in the public domain
+\newcommand*{\myjobname}{}
+\newcommand*{\setmyjobname}{\expanded{\noexpand\setmyjobnameaux
+  \jobname"\jobname"\relax}}
+\newcommand*{\setmyjobnameaux}{}
+\def\setmyjobnameaux#1"#2"#3\relax{\def\myjobname{#2}}
+\setmyjobname
+
+\def\PlantUMLJobname{\myjobname\thePlantUmlFigureNumberSVG}
 
 \ExplSyntaxOn
 \keys_define:nn { plantuml } {
@@ -80,7 +89,7 @@
     }
   \fi
   \NewDocumentEnvironment{plantuml}{}{%
-    \VerbatimOut{\CurrentDirectory\PlantUMLJobname-plantuml.txt}}
+    \VerbatimOut{"\CurrentDirectory\PlantUMLJobname-plantuml.txt"}}
   {%
     \endVerbatimOut
     \ifluatex
@@ -92,7 +101,7 @@
       }
     \else
       \stepcounter{PlantUmlFigureNumber}
-      %TODO: Execute pyhton here
+      %TODO: Execute python here
       \typeout{*** plantuml only works with lualatex ***}
     \fi
     \ifthenelse{\equal{\PlantUmlMode}{latex}}{


### PR DESCRIPTION
I am suffering from the same problem as in #31. Adding quotes (" ") in `plantuml.lua`, `plantuml.sty` and `\epstopdfDeclareGraphicsRule` in the LaTeX file (when Inkscape is used) should help.

I have only tested in on my Linux machine with this command: `lualatex --shell-escape -cnf-line=openout_any=a "my file.tex"`, so it would be great if more tests can be done.