### PR TITLE
Fix infinite loop when using latexmk with SVG output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed infinite loop when using latexmk with SVG output, by executing PlantUML only if the code is changed. [#49](https://github.com/koppor/plantuml/pull/49)
+- Fixed Incorrect file name when file name is specified after `@startuml`. [#49](https://github.com/koppor/plantuml/pull/49#issuecomment-2867843869)
+
 ## [0.5.1] - 2025-05-09
 
 ### Fixed

--- a/plantuml.lua
+++ b/plantuml.lua
@@ -38,10 +38,10 @@ function convertPlantUmlToTikz(jobname, mode)
       return
     else
       texio.write_nl("Source \"" .. plantUmlSourceFilename .. "\" has changed. ")
-      -- delete generated file to ensure they are really recreated
-      os.remove(plantUmlTargetFilename)
     end
   end
+  -- delete generated file to ensure they are really recreated
+  os.remove(plantUmlTargetFilename)
 
   texio.write("Executing PlantUML... ")
   local cmd = "java -Djava.awt.headless=true -jar " .. plantUmlJar .. " -charset UTF-8 -t"
@@ -72,6 +72,7 @@ function convertPlantUmlToTikz(jobname, mode)
     return
   else
     -- cache plantUmlSourceFilename for next run
+    texio.write_nl("Caching source file \"" .. plantUmlSourceFilename .. "\" to \"" .. sourceCacheFilename .. "\".")
     local sourceHandle = io.open(plantUmlSourceFilename, "r")
     if sourceHandle then
       local cacheHandle = io.open(sourceCacheFilename, "w")

--- a/plantuml.lua
+++ b/plantuml.lua
@@ -44,7 +44,7 @@ function convertPlantUmlToTikz(jobname, mode)
   os.remove(plantUmlTargetFilename)
 
   texio.write("Executing PlantUML... ")
-  local cmd = "java -Djava.awt.headless=true -jar " .. plantUmlJar .. " -charset UTF-8 -t"
+  local cmd = "java -Djava.awt.headless=true -jar " .. plantUmlJar .. " -charset UTF-8 -pipe -t"
   if (mode == "latex") then
     cmd = cmd .. "latex:nopreamble"
     -- plantuml has changed output format in https://github.com/plantuml/plantuml/pull/1237
@@ -54,7 +54,7 @@ function convertPlantUmlToTikz(jobname, mode)
   end
 
 
-  cmd = cmd .. [[ "]] .. plantUmlSourceFilename .. [["]]
+  cmd = cmd .. [[ < "]] .. plantUmlSourceFilename .. [[" > "]] .. plantUmlTargetFilename .. [["]]
   texio.write_nl(cmd)
   local handle,error = io.popen(cmd)
   if not handle then


### PR DESCRIPTION
When outputing SVG, the generated PDF is updated every time. As latexmk detects a change in the PDF file, it will keep re-run until maximum runs reached.

I execute latexmk with the following: `latexmk -lualatex --shell-escape -recorder main.tex`

My solution is as following:
After PlantUML is executed, the source `*-plantuml.txt` is copied to `*-plantuml.txt.<mode>.cache`, and in the next run, if the cache is the same as the source, PlantUML is skipped, hence not creating new SVG.